### PR TITLE
New functionality in ETD class

### DIFF
--- a/packageETDs.py
+++ b/packageETDs.py
@@ -1,2 +1,0 @@
-from packages import ETD
-

--- a/parse_pq_xml.py
+++ b/parse_pq_xml.py
@@ -1,0 +1,42 @@
+from packages import etd_loop, etd_total
+from tqdm import tqdm
+
+dept_names = []
+disciplines = {}
+degrees = []
+lang_codes = []
+
+for etd in tqdm(etd_loop(), total=etd_total()):
+
+	xml = etd.pq_xml()
+
+	dept = xml.find("DISS_description/DISS_institution/DISS_inst_contact").text
+	if dept not in dept_names:
+		dept_names.append(dept)
+
+	categories = xml.find("DISS_description/DISS_categorization")
+	for catagory in categories:
+		if catagory.tag == "DISS_category":
+			discipline = catagory.find("DISS_cat_desc").text
+			code = catagory.find("DISS_cat_code").text
+			if code not in disciplines.keys():
+				disciplines[code] = discipline
+
+	degree = xml.find("DISS_description/DISS_degree").text
+	if degree not in degrees:
+		degrees.append(degree)
+
+	lang = categories.find("DISS_language").text
+	if lang not in lang_codes:
+		lang_codes.append(lang)
+
+print ("departments:")
+for dept in dept_names:
+	print (f"\t{dept}")
+
+print ("disciplines:")
+for code in disciplines.keys():
+	print (f"\t{code}: {disciplines[code]}")
+
+print (degrees)
+print (lang_codes)


### PR DESCRIPTION
Added a `pq_xml()` function to parse PQ xml files so we don't have to identify the XML file and parse it in every script. You can now:
```
etd = ETD()
etd.load(path)
xml = etd.pq_xml()
print (xml.tag)
for stuff in xml.xpath("blah..."):
    # do stuff
```

Also added a `etd_loop` generator to loop though all ETDs or all ETDs for a certain year since I keep finding myself doing that in scripts. You can now:
```
for etd in etd_loop():
    #do stuff
```

`etd_total()` also returns the total number of ETDs, so you can use tqdm like this:
```
for etd in tqdm(etd_loop(), total=etd_total()):
    #do stuff with progress bar
```